### PR TITLE
Fix Vercel build by adding missing Vite React plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+.env
+.vercel

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^18.2.17",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
+    "@vitejs/plugin-react": "^4.3.2",
     "tailwindcss": "^3.4.10",
     "vite": "^5.4.0"
   }


### PR DESCRIPTION
## Summary
- add the official Vite React plugin to the devDependencies required by vite.config.js
- add a .gitignore so transient build artifacts such as node_modules and dist are not committed

## Testing
- npm install *(fails: npm cannot download @vitejs/plugin-react in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f688b8d0e483298a9f0cf971375c2e